### PR TITLE
Fixes reported issue #13

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -246,7 +246,9 @@ class BE_Genesis_Grid {
 		$grid_args = $this->be_grid_loop_pagination();
 		if( ! $grid_args )
 			return;
-	
+		if ( -1 === $wp_query->query_vars[posts_per_page] )
+			return;
+
 		$max = ceil ( ( $wp_query->found_posts - $grid_args['features_on_front'] - $grid_args['teasers_on_front'] ) / ( $grid_args['features_inside'] + $grid_args['teasers_inside'] ) ) + 1;
 		$wp_query->max_num_pages = $max;
 		


### PR DESCRIPTION
By not checking for posts_per_page = -1, you're forcing pagination on a page where it is not required. This patch fixes that issue.